### PR TITLE
Fix redirect endpoint in webapp

### DIFF
--- a/webapp.py
+++ b/webapp.py
@@ -99,7 +99,7 @@ def upload_resources():
             session["cl_json"] = str(cl_json_path)
             session["taxonomy"] = str(taxonomy_path)
             session["model_dir"] = model_dir
-            return redirect(url_for("run_pipeline"))
+            return redirect(url_for("run_pipeline_route"))
         flash("All files required")
     return render_template_string(UPLOAD_RESOURCES_HTML)
 


### PR DESCRIPTION
## Summary
- fix wrong endpoint name for running pipeline

## Testing
- `python -m compileall -q webapp.py interactive_trophoblast_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_6870cc27188483268b319b01605b387b